### PR TITLE
Revisions to phpstan configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "nunomaduro/larastan": "^2.0",
+        "larastan/larastan": "^2.9",
         "friendsofphp/php-cs-fixer": "^3.6",
         "symfony/filesystem": "^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,9 @@
         "php": "^8.1",
         "larastan/larastan": "^2.9",
         "friendsofphp/php-cs-fixer": "^3.6",
-        "symfony/filesystem": "^6.0"
+        "symfony/filesystem": "^6.0",
+        "phpstan/phpstan-mockery": "^1.1.2",
+        "phpstan/phpstan-phpunit": "^1.3.16"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "larastan/larastan": "^2.9",
+        "larastan/larastan": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.6",
         "symfony/filesystem": "^6.0",
         "phpstan/phpstan-mockery": "^1.1.2",

--- a/phpstan/extension.neon
+++ b/phpstan/extension.neon
@@ -1,5 +1,7 @@
 includes:
   - ../../../larastan/larastan/extension.neon
+  - ../../../phpstan/phpstan-phpunit/extension.neon
+  - ../../../phpstan/phpstan-mockery/extension.neon
 
 parameters:
     level: 6

--- a/phpstan/extension.neon
+++ b/phpstan/extension.neon
@@ -1,5 +1,5 @@
 includes:
-  - ../../../nunomaduro/larastan/extension.neon
+  - ../../../larastan/larastan/extension.neon
 
 parameters:
     level: 6


### PR DESCRIPTION
`nunomaduro/larastan` is deprecated in favour of `larastan/larastan` so i've replaced it  

additionally includes the `mockery` and `phpunit` first-party [phpstan extensions](https://phpstan.org/user-guide/extension-library#official-extensions) that would allow us to begin using phpstan to analyze test code aswell as production code

analyzing test code has value as it provides another reassurance that our tests are of good quality and don't include dead code, have type errors etc. in them, and gives devs more feedback during writing their tests if they have their editors configured to

for repos that aren't currently analyzing their test code these additions will have minimal performance impact due to the way phpstan handles extensions internally so it's no issue including them when they are no used