### PR TITLE
Fix deprecated parameters and add generic mongodb model `where` to ignore error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.neon]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,3 @@ trim_trailing_whitespace = false
 
 [*.{yml,yaml}]
 indent_size = 2
-
-[*.neon]
-indent_style = tab

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # code-standards-laravel
 
 Composer package providing pre-configured quality tools for our Laravel projects.
+
+Validate `.neon` files locally:
+
+```bash
+composer global require nette/neon
+composer global exec neon-lint .
+```

--- a/phpstan/extension.neon
+++ b/phpstan/extension.neon
@@ -8,3 +8,6 @@ parameters:
 
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
+
+	ignoreErrors:
+	- message: '#Call to an undefined method MongoDB\\Laravel\\Relations\\EmbedsMany<[a-zA-Z0-9\\_]+>::where\(\)#'

--- a/phpstan/extension.neon
+++ b/phpstan/extension.neon
@@ -6,8 +6,7 @@ includes:
 parameters:
     level: 6
 
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
-
     ignoreErrors:
+    - identifier: missingType.iterableValue
+    - identifier: missingType.generics
     - message: '#Call to an undefined method MongoDB\\Laravel\\Relations\\EmbedsMany<[a-zA-Z0-9\\_]+>::where\(\)#'

--- a/phpstan/extension.neon
+++ b/phpstan/extension.neon
@@ -1,7 +1,7 @@
 includes:
-  - ../../../larastan/larastan/extension.neon
-  - ../../../phpstan/phpstan-phpunit/extension.neon
-  - ../../../phpstan/phpstan-mockery/extension.neon
+    - ../../../larastan/larastan/extension.neon
+    - ../../../phpstan/phpstan-phpunit/extension.neon
+    - ../../../phpstan/phpstan-mockery/extension.neon
 
 parameters:
     level: 6
@@ -9,5 +9,5 @@ parameters:
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
 
-	ignoreErrors:
-	- message: '#Call to an undefined method MongoDB\\Laravel\\Relations\\EmbedsMany<[a-zA-Z0-9\\_]+>::where\(\)#'
+    ignoreErrors:
+    - message: '#Call to an undefined method MongoDB\\Laravel\\Relations\\EmbedsMany<[a-zA-Z0-9\\_]+>::where\(\)#'


### PR DESCRIPTION
When calling `->where()` on a relationship in a mongodb model, it often raises errors:

<img width="1389" alt="image" src="https://github.com/yourparkingspace/code-standards-laravel/assets/5834879/9a4b30ed-953c-4499-9fc1-0f709293bec9">

These are often added to project specific ignore files, e.g. https://github.com/search?q=org%3Ayourparkingspace+mongodb+language%3ANEON&type=code

This should stop this being required. In use in this PR https://github.com/yourparkingspace/products/pull/73/files

---

Deprecated parameters.

Running `composer update` in a project to bring in latest changes and then running `vendor/bin/phpstan` will give this output:

<pre>
Note: Using configuration file /var/www/phpstan.neon.
⚠️  You're using a deprecated config option checkMissingIterableValueType ⚠️️

It's strongly recommended to remove it from your configuration file
and add the missing array typehints.

If you want to continue ignoring missing typehints from arrays,
add missingType.iterableValue error identifier to your ignoreErrors:

parameters:
        ignoreErrors:
                -
                        identifier: missingType.iterableValue

⚠️  You're using a deprecated config option checkGenericClassInNonGenericObjectType ⚠️️

It's strongly recommended to remove it from your configuration file
and add the missing generic typehints.

If you want to continue ignoring missing typehints from generics,
add missingType.generics error identifier to your ignoreErrors:

parameters:
        ignoreErrors:
                -
                        identifier: missingType.generics
</pre>

<img width="1633" alt="image" src="https://github.com/yourparkingspace/code-standards-laravel/assets/5834879/6eb3a2ae-84a8-449b-8fe8-c76ae4013226">
